### PR TITLE
fix(resource): swap Answer and Exam branch contents to get original output

### DIFF
--- a/src/resource.js
+++ b/src/resource.js
@@ -17,9 +17,9 @@ export const ResourceType = {
 function getNzqaResourceTypeUri(resourceType) {
 	switch (resourceType) {
 		case ResourceType.Answer:
-			return { longResource: "exams", shortResource: "exm" };
-		case ResourceType.Exam:
 			return { longResource: "schedules", shortResource: "ass" };
+		case ResourceType.Exam:
+			return { longResource: "exams", shortResource: "exm" };
 		case ResourceType.Formula:
 			return { longResource: "exams", shortResource: "res" };
 	}


### PR DESCRIPTION
This fixes a regression introduced in #1 where the first two switch arms were unintentionally swapped. This change should result in the intended output.